### PR TITLE
Update os in github.yml from Ubuntu 20.04 to 22.04

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -21,7 +21,9 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        ## OLD: EOL for Ubuntu 20.04
+        # os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
         ## TODO: os: [ubuntu-20.04, ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10"]
         ## TODO: 3.x [latest; -or latest, latest-1, latest-2, ...]


### PR DESCRIPTION
20.04 reaches EOL, this patch is for checking if upgrade to 22.04 helps to detect changes in fix/perl-to-python branch (this issue is not present for newer branches, as the version is updated to 22.04)